### PR TITLE
Make 3.5.0 verify:release green (ClassScout WIP + dev advisories)

### DIFF
--- a/apps/playground/src/generated-site-phrases.ts
+++ b/apps/playground/src/generated-site-phrases.ts
@@ -881,6 +881,17 @@ export const generatedSitePhrases = {
     "fr": "Les produits authentifiés nécessitent une coque structurelle stable avec un emplacement et un rythme de destination évidents.",
     "hu": "A hitelesített termékeknek egyetlen stabil szerkezeti héjra van szükségük, egyértelmű elhelyezkedéssel és rendeltetési ritmussal."
   },
+  "p_38d8694c380b": {
+    "en": "Authenticating your demo identity and role to unlock premium content.",
+    "ar": "التحقق من هويتك التجريبية ودورك لفتح المحتوى المتميز.",
+    "de": "Authentifizieren Sie Ihre Demo-Identität und -Rolle, um Premium-Inhalte freizuschalten.",
+    "fr": "Authentifier votre identité de démonstration et votre rôle pour débloquer du contenu premium.",
+    "it": "Autentica la tua identità e il tuo ruolo demo per sbloccare contenuti premium.",
+    "he": "אימות הזהות ותפקיד ההדגמה שלך כדי לפתוח תוכן פרימיום.",
+    "hu": "A demóazonosító és szerepkör hitelesítése a prémium tartalom feloldásához.",
+    "es": "Autenticar su identidad y rol de demostración para desbloquear contenido premium.",
+    "ru": "Аутентификация вашей демо-личности и роли для разблокировки премиум-контента."
+  },
   "p_4021ef2fc383": {
     "en": "Avoid local component duplication.",
     "es": "Evite la duplicación de componentes locales.",
@@ -1695,6 +1706,17 @@ export const generatedSitePhrases = {
     "hu": "Kiválasztás törlése",
     "he": "נקה בחירה"
   },
+  "p_13673180377e": {
+    "en": "Click to login",
+    "ru": "Нажмите, чтобы войти",
+    "ar": "انقر لتسجيل الدخول",
+    "fr": "Cliquez pour vous connecter",
+    "de": "Klicken Sie hier, um sich anzumelden",
+    "hu": "Kattintson a bejelentkezéshez",
+    "it": "Fare clic per accedere",
+    "he": "לחץ כדי להיכנס",
+    "es": "Haga clic para iniciar sesión"
+  },
   "p_edfb29e935df": {
     "en": "Cluster A",
     "es": "Grupo A",
@@ -2025,17 +2047,6 @@ export const generatedSitePhrases = {
     "de": "Als Gast fortfahren",
     "hu": "Továbbra is vendégként"
   },
-  "p_acb4c05a1787": {
-    "en": "Continue with membership",
-    "ru": "Продолжить членство",
-    "es": "Continuar con la membresía",
-    "ar": "تواصل مع العضوية",
-    "fr": "Continuer avec l'adhésion",
-    "hu": "Folytassa a tagsággal",
-    "it": "Continua con l'iscrizione",
-    "de": "Fahren Sie mit der Mitgliedschaft fort",
-    "he": "המשך בחברות"
-  },
   "p_116a311ba5c6": {
     "en": "Controlled freshness and helper copy contract.",
     "de": "Kontrollierte Frische und Hilfskopievertrag.",
@@ -2332,17 +2343,6 @@ export const generatedSitePhrases = {
     "ru": "Опишите недостающий примитив или поведение.",
     "fr": "Décrivez la primitive ou le comportement manquant.",
     "hu": "Ismertesse a hiányzó primitívet vagy viselkedést!"
-  },
-  "p_bd6a02e30899": {
-    "en": "Design system paywall pattern",
-    "it": "Modello di paywall del sistema di progettazione",
-    "ru": "Шаблон платного доступа в системе разработки",
-    "fr": "Modèle de paywall du système de conception",
-    "es": "Patrón de muro de pago del sistema de diseño",
-    "ar": "نمط تصميم نظام حظر الاشتراك غير المدفوع",
-    "de": "Design-System-Paywall-Muster",
-    "hu": "Tervezési rendszer fizetőfal minta",
-    "he": "עיצוב דפוס חומת תשלום של מערכת"
   },
   "p_a2ae49bddabd": {
     "en": "Desktop tables must adapt through scroll, cards, priority columns, or stacked rows rather than naive shrinking.",
@@ -4961,6 +4961,17 @@ export const generatedSitePhrases = {
     "es": "Mapa de ruta de la reunión",
     "hu": "Találkozási útvonal térkép",
     "he": "מפת מסלולי Meetup"
+  },
+  "p_ea7070ee9a06": {
+    "en": "Member unlocked",
+    "fr": "Membre débloqué",
+    "it": "Membro sbloccato",
+    "ar": "تم فتح العضو",
+    "he": "חבר לא נעול",
+    "es": "Miembro desbloqueado",
+    "de": "Mitglied freigeschaltet",
+    "hu": "Tag feloldva",
+    "ru": "Участник разблокирован"
   },
   "p_16f5d4b1b0ef": {
     "en": "Messaging Primitives",
@@ -8570,6 +8581,28 @@ export const generatedSitePhrases = {
     "hu": "Jelentkezzen be a GDS-be",
     "de": "Melden Sie sich bei GDS an"
   },
+  "p_48f0d3d397d4": {
+    "en": "Sign out",
+    "de": "Abmelden",
+    "it": "disconnessione",
+    "fr": "se déconnecter",
+    "es": "desconectar",
+    "ru": "выход",
+    "he": "צא",
+    "ar": "تسجيل الخروج",
+    "hu": "Jelentkezzen ki"
+  },
+  "p_824a1d703ce6": {
+    "en": "Signing in",
+    "de": "Anmelden",
+    "fr": "Connexion",
+    "es": "Iniciar sesión",
+    "ar": "تسجيل الدخول",
+    "hu": "Bejelentkezés",
+    "it": "Accesso",
+    "ru": "Вход в систему",
+    "he": "כניסה"
+  },
   "p_a84af9418ab0": {
     "en": "Simple Data Tables",
     "he": "טבלאות נתונים פשוטות",
@@ -9307,17 +9340,6 @@ export const generatedSitePhrases = {
     "fr": "Le fichier sélectionné est plus grand que la taille autorisée.",
     "hu": "A kiválasztott fájl nagyobb, mint a megengedett méret."
   },
-  "p_f23ebaf883d3": {
-    "en": "The teaser is public. The member-only body is never rendered until the session and entitlement are allowed.",
-    "es": "El teaser es público. El organismo exclusivo para miembros nunca se presenta hasta que se permitan la sesión y los derechos.",
-    "de": "Der Teaser ist öffentlich. Der Nur-Mitglieder-Körper wird niemals gerendert, bis die Sitzung und die Berechtigung zugelassen sind.",
-    "fr": "Le teaser est public. Le corps réservé aux membres n'est jamais rendu tant que la session et les droits ne sont pas autorisés.",
-    "ru": "Тизер является публичным. Тело, предназначенное только для членов, никогда не отображается до тех пор, пока не будут разрешены сеанс и право.",
-    "it": "Il teaser è pubblico. Il corpo riservato ai soli membri non viene mai visualizzato finché non vengono consentiti la sessione e il diritto.",
-    "he": "הטיזר פומבי. הגוף לחבר בלבד לעולם אינו מוצג עד שההפעלה והזכאות מותרים.",
-    "ar": "الجملة التشويقية عامة. لا يتم أبدًا تقديم الهيئة المخصصة للأعضاء فقط حتى يتم السماح بالجلسة والاستحقاق.",
-    "hu": "Az előzetes nyilvános. A csak tagoknak szóló testület addig nem jelenik meg, amíg a munkamenet és a jogosultság nem engedélyezett."
-  },
   "p_621d23b1656a": {
     "en": "Theme explorer, docs sections, locale notices, and proof grids used by the official site.",
     "es": "Explorador de temas, secciones de documentos, avisos locales y cuadrículas de prueba utilizadas por el sitio oficial.",
@@ -9417,16 +9439,16 @@ export const generatedSitePhrases = {
     "de": "Dieser Katalog ordnet den dokumentierten Musterbestand einem Live-Laufzeitnachweis zu. Der Markdown-SSOT bleibt normativ und diese Website dient als visuelle Referenz.",
     "hu": "Ez a katalógus leképezi a dokumentált mintakészletet élő futásidejű bizonyításra. A leértékelés SSOT továbbra is normatív, és ez a webhely a vizuális referencia."
   },
-  "p_36b95b719349": {
-    "en": "This content only mounts after the access resolver returns unlocked.",
-    "ru": "Это содержимое монтируется только после того, как преобразователь доступа снова разблокируется.",
-    "it": "Questo contenuto viene montato solo dopo che il risolutore di accesso ritorna sbloccato.",
-    "ar": "يتم تحميل هذا المحتوى فقط بعد عودة أداة حل الوصول إلى إلغاء القفل.",
-    "de": "Dieser Inhalt wird erst bereitgestellt, nachdem der Access Resolver wieder entsperrt ist.",
-    "es": "Este contenido solo se monta después de que el solucionador de acceso vuelve a estar desbloqueado.",
-    "fr": "Ce contenu n'est monté qu'une fois que le résolveur d'accès est revenu déverrouillé.",
-    "hu": "Ez a tartalom csak akkor jelenik meg, ha a hozzáférés-feloldó feloldva tér vissza.",
-    "he": "תוכן זה נטען רק לאחר שפותר הגישה חוזר ללא נעילה."
+  "p_c37617048a2f": {
+    "en": "This content only mounts after the access state is unlocked.",
+    "ar": "يتم تحميل هذا المحتوى فقط بعد إلغاء قفل حالة الوصول.",
+    "es": "Este contenido solo se monta después de que se desbloquea el estado de acceso.",
+    "fr": "Ce contenu n'est monté qu'une fois l'état d'accès déverrouillé.",
+    "de": "Dieser Inhalt wird erst bereitgestellt, nachdem der Zugriffsstatus entsperrt wurde.",
+    "ru": "Этот контент монтируется только после разблокировки состояния доступа.",
+    "it": "Questo contenuto viene montato solo dopo che lo stato di accesso è stato sbloccato.",
+    "hu": "Ez a tartalom csak a hozzáférési állapot feloldása után épül fel.",
+    "he": "תוכן זה נטען רק לאחר ביטול הנעילה של מצב הגישה."
   },
   "p_712c488cba58": {
     "en": "This documented pattern is represented through the shared component family.",
@@ -10231,16 +10253,16 @@ export const generatedSitePhrases = {
     "hu": "Használja a megosztott PublicFoodCard-ot az egyértelmű elérhetőséggel és segítő jelzésekkel rendelkező menüelemekhez.",
     "de": "Nutzen Sie die gemeinsame PublicFoodCard für Menüpunkte mit klarer Verfügbarkeit und Helferhinweisen."
   },
-  "p_56eaeb4dc442": {
-    "en": "Use this boundary when a page can show summary content while protecting premium or private detail.",
-    "ar": "استخدم هذا الحد عندما تتمكن الصفحة من عرض محتوى ملخص مع حماية التفاصيل المميزة أو الخاصة.",
-    "it": "Utilizza questo limite quando una pagina può mostrare contenuti di riepilogo proteggendo al tempo stesso i dettagli premium o privati.",
-    "es": "Utilice este límite cuando una página pueda mostrar contenido resumido y al mismo tiempo proteger detalles premium o privados.",
-    "de": "Verwenden Sie diese Grenze, wenn eine Seite zusammenfassende Inhalte anzeigen und gleichzeitig Premium- oder private Details schützen kann.",
-    "ru": "Используйте эту границу, если на странице можно отображать сводный контент, защищая при этом премиум- или личную информацию.",
-    "fr": "Utilisez cette limite lorsqu'une page peut afficher un contenu récapitulatif tout en protégeant les détails premium ou privés.",
-    "hu": "Használja ezt a határt, ha egy oldal összefoglaló tartalmat jeleníthet meg, miközben védi a prémium vagy privát részleteket.",
-    "he": "השתמש בגבול זה כאשר דף יכול להציג תוכן סיכום תוך הגנה על פרטי פרימיום או פרטיים."
+  "p_5e03f60ce3e8": {
+    "en": "Use this boundary when a page can show summary content while protecting premium or private detail. The protected member section is never mounted until unlocked.",
+    "de": "Verwenden Sie diese Grenze, wenn eine Seite zusammenfassende Inhalte anzeigen und gleichzeitig Premium- oder private Details schützen kann. Der geschützte Mitgliedsbereich wird erst dann gemountet, wenn er entsperrt ist.",
+    "ru": "Используйте эту границу, если на странице можно отображать сводный контент, защищая при этом премиум- или личную информацию. Защищенный раздел участников никогда не монтируется, пока не разблокирован.",
+    "it": "Utilizza questo limite quando una pagina può mostrare contenuti di riepilogo proteggendo al tempo stesso i dettagli premium o privati. La sezione del membro protetto non viene mai montata finché non viene sbloccata.",
+    "ar": "استخدم هذا الحد عندما تتمكن الصفحة من عرض محتوى ملخص مع حماية التفاصيل المميزة أو الخاصة. لا يتم تثبيت قسم العضو المحمي أبدًا حتى يتم إلغاء قفله.",
+    "es": "Utilice este límite cuando una página pueda mostrar contenido resumido y al mismo tiempo proteger detalles premium o privados. La sección de miembros protegidos nunca se monta hasta que se desbloquea.",
+    "fr": "Utilisez cette limite lorsqu'une page peut afficher un contenu récapitulatif tout en protégeant les détails premium ou privés. La section de membre protégée n'est jamais montée tant qu'elle n'est pas déverrouillée.",
+    "hu": "Használja ezt a határt, ha egy oldal összefoglaló tartalmat jeleníthet meg, miközben védi a prémium vagy privát részleteket. A védett tagrészt soha nem szerelik fel, amíg ki nem oldják.",
+    "he": "השתמש בגבול זה כאשר דף יכול להציג תוכן סיכום תוך הגנה על פרטי פרימיום או פרטיים. חלק החבר המוגן לעולם אינו מותקן עד לביטול הנעילה."
   },
   "p_cbc42c2bc13f": {
     "en": "Use this panel as the canonical bounded composition for grouped content.",
@@ -10318,17 +10340,6 @@ export const generatedSitePhrases = {
     "ar": "يجب أن يتم تشغيل الفيديو والوسائط الموقوتة من خلال عقد التشغيل الأساسي.",
     "ru": "Воспроизведение видео и мультимедиа по времени должно выполняться через контракт канонического воспроизведения.",
     "he": "הפעלת וידאו ומדיה מתוזמנת צריכה להיות עיבוד באמצעות חוזה ההשמעה הקנוני."
-  },
-  "p_560ed268ef7e": {
-    "en": "View membership",
-    "es": "Ver membresía",
-    "fr": "Voir l'adhésion",
-    "ar": "عرض العضوية",
-    "he": "צפה בחברות",
-    "ru": "Посмотреть членство",
-    "hu": "Tagság megtekintése",
-    "de": "Mitgliedschaft anzeigen",
-    "it": "Visualizza l'appartenenza"
   },
   "p_c56bdc732b1b": {
     "en": "Visible aggregate.",

--- a/apps/playground/src/pattern-pages.tsx
+++ b/apps/playground/src/pattern-pages.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   AccessSummary,
   AccessRecoveryPanel,
@@ -14,6 +14,8 @@ import {
   ConfirmDialog,
   ConsumerDashboardGrid,
   ConsumerSection,
+  type GdsAccessGateAction,
+  resolveGdsAccessState,
   createGdsVocabularyPack,
   DataToolbar,
   ListingProvider,
@@ -308,6 +310,105 @@ function TelemetryDemo() {
     <GdsTelemetryProvider sink={(event) => setEvents((current) => [...current, `${event.component}:${event.eventType}`])}>
       <TelemetryProbe events={events} />
     </GdsTelemetryProvider>
+  );
+}
+
+function AccessGatePlaygroundDemo() {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isSigningIn, setIsSigningIn] = useState(false);
+
+  useEffect(() => {
+    if (!isSigningIn) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setIsAuthenticated(true);
+      setIsSigningIn(false);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [isSigningIn]);
+
+  const baseContract = resolveGdsAccessState({
+    gateId: 'article-paywall-demo',
+    session: isSigningIn
+      ? { status: 'loading' }
+      : isAuthenticated
+        ? { status: 'authenticated', subjectId: 'demo-user' }
+        : { status: 'anonymous' },
+    entitlement: isAuthenticated ? { allowed: true, label: 'Member' } : undefined,
+  });
+
+  const contract = isSigningIn
+    ? {
+        ...baseContract,
+        state: 'unlocking' as const,
+        reason: baseContract.reason ?? 'login-required',
+        title: 'Signing in',
+        description: 'Authenticating your demo identity and role to unlock premium content.',
+      }
+    : baseContract;
+
+  const previewTitle = isAuthenticated ? 'Member unlocked' : 'Article preview';
+
+  const beginSignIn = () => {
+    if (isSigningIn || isAuthenticated) {
+      return;
+    }
+
+    setIsSigningIn(true);
+  };
+
+  const beginSignOut = () => {
+    setIsSigningIn(false);
+    setIsAuthenticated(false);
+  };
+
+  const handleAction = (action: GdsAccessGateAction) => {
+    if (action.kind === 'sign-in' || action.kind === 'sign-up') {
+      beginSignIn();
+    }
+  };
+
+  return (
+    <div>
+      <GdsAccessGate
+        {...contract}
+        protectedContentPolicy="never-render-while-locked"
+        teaserLabel="Article preview"
+        entitlementLabel="Member"
+        preview={
+          <div>
+            <h4>{previewTitle}</h4>
+            <p>
+              Use this boundary when a page can show summary content while protecting premium or private detail.
+              The protected member section is never mounted until unlocked.
+            </p>
+          </div>
+        }
+        protectedContent={() => (
+          <div>
+            <h4>Protected member-only article body</h4>
+            <p>This content only mounts after the access state is unlocked.</p>
+          </div>
+        )}
+        onAction={handleAction}
+      />
+      <div>
+        <button type="button" onClick={beginSignIn} disabled={isSigningIn || isAuthenticated}>
+          Click to login
+        </button>
+        {isAuthenticated ? (
+          <>
+            {' '}
+            <button type="button" onClick={beginSignOut}>
+              Sign out
+            </button>
+          </>
+        ) : null}
+      </div>
+    </div>
   );
 }
 
@@ -1259,34 +1360,7 @@ function renderEntryDemo(entry: PatternRegistryEntry) {
         </div>
       );
     case 'access-gates':
-      return (
-        <GdsAccessGate
-          id="article-paywall-demo"
-          state="locked"
-          reason="subscription-required"
-          title="Continue with membership"
-          description="The teaser is public. The member-only body is never rendered until the session and entitlement are allowed."
-          entitlementLabel="Member"
-          teaserLabel="Article preview"
-          actions={[
-            { kind: 'subscribe', label: 'View membership' },
-            { kind: 'sign-in', label: 'Sign in' },
-          ]}
-          protectedContentPolicy="never-render-while-locked"
-          preview={
-            <div>
-              <h4>Design system paywall pattern</h4>
-              <p>Use this boundary when a page can show summary content while protecting premium or private detail.</p>
-            </div>
-          }
-          protectedContent={() => (
-            <div>
-              <h4>Protected member-only article body</h4>
-              <p>This content only mounts after the access resolver returns unlocked.</p>
-            </div>
-          )}
-        />
-      );
+      return <AccessGatePlaygroundDemo />;
     case 'placeholder-panels':
       return (
         <PlaceholderPanel

--- a/apps/playground/tsconfig.app.json
+++ b/apps/playground/tsconfig.app.json
@@ -6,7 +6,7 @@
     "lib": ["ES2023", "DOM"],
     "ignoreDeprecations": "6.0",
     "module": "esnext",
-    "types": ["vite/client", "vitest/globals"],
+    "types": ["vite/client", "vitest/globals", "node"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/docs/ACCESS_GATE.md
+++ b/docs/ACCESS_GATE.md
@@ -107,5 +107,6 @@ Package verification:
 ## Documentation And Demo
 
 - Live demo: `https://sovereignsquad.github.io/general-design-system/patterns/access#access-gates`
+- The access-gate live demo now includes a built-in `Click to login` control for a quick locked/unlocked comparison on the same page.
 - API coverage: `GdsAccessGate`, state/reason registries, action sorting, contract validation, access resolver, adapter resolver, and event helpers are covered by the pattern export registry.
 - Related primitives: `AccessSummary`, `AccessRecoveryPanel`, `AuthShell`, `ProviderIdentityButtonGroup`, and `GdsTelemetryProvider`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "general-design-system",
-  "version": "3.4.14",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "general-design-system",
-      "version": "3.4.14",
+      "version": "3.5.0",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -33,11 +33,11 @@
       }
     },
     "apps/playground": {
-      "version": "3.4.14",
+      "version": "3.5.0",
       "dependencies": {
-        "@doneisbetter/gds-admin": "3.4.14",
-        "@doneisbetter/gds-core": "3.4.14",
-        "@doneisbetter/gds-theme": "3.4.14",
+        "@doneisbetter/gds-admin": "3.5.0",
+        "@doneisbetter/gds-core": "3.5.0",
+        "@doneisbetter/gds-theme": "3.5.0",
         "@floating-ui/core": "^1.7.5",
         "@mantine/core": "^7.9.0",
         "@mantine/hooks": "^7.9.0",
@@ -101,10 +101,10 @@
       }
     },
     "apps/reference-next": {
-      "version": "3.4.14",
+      "version": "3.5.0",
       "dependencies": {
-        "@doneisbetter/gds-core": "3.4.14",
-        "@doneisbetter/gds-theme": "3.4.14",
+        "@doneisbetter/gds-core": "3.5.0",
+        "@doneisbetter/gds-theme": "3.5.0",
         "@mantine/core": "^7.9.0",
         "@mantine/hooks": "^7.9.0",
         "react": "^18.3.1",
@@ -159,10 +159,10 @@
       }
     },
     "apps/reference-vite": {
-      "version": "3.4.14",
+      "version": "3.5.0",
       "dependencies": {
-        "@doneisbetter/gds-core": "3.4.14",
-        "@doneisbetter/gds-theme": "3.4.14",
+        "@doneisbetter/gds-core": "3.5.0",
+        "@doneisbetter/gds-theme": "3.5.0",
         "@floating-ui/core": "^1.7.5",
         "@mantine/core": "^7.9.0",
         "@mantine/hooks": "^7.9.0",
@@ -1394,14 +1394,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -1433,7 +1433,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1441,9 +1443,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1488,9 +1490,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1505,9 +1507,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1522,9 +1524,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1542,9 +1544,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1562,9 +1564,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1582,9 +1584,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -1621,9 +1623,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -1641,9 +1643,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1658,9 +1660,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1677,9 +1679,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1694,9 +1696,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -4554,11 +4556,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -4568,21 +4572,75 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/rollup": {
@@ -4872,7 +4930,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5192,15 +5252,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.14",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.2",
-        "tinyglobby": "^0.2.16"
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5521,16 +5583,16 @@
     },
     "packages/gds": {
       "name": "@doneisbetter/gds",
-      "version": "3.4.14",
+      "version": "3.5.0",
       "dependencies": {
-        "@doneisbetter/gds-admin": "3.4.14",
-        "@doneisbetter/gds-core": "3.4.14",
-        "@doneisbetter/gds-theme": "3.4.14"
+        "@doneisbetter/gds-admin": "3.5.0",
+        "@doneisbetter/gds-core": "3.5.0",
+        "@doneisbetter/gds-theme": "3.5.0"
       },
       "devDependencies": {
-        "@doneisbetter/gds-admin": "3.4.14",
-        "@doneisbetter/gds-core": "3.4.14",
-        "@doneisbetter/gds-theme": "3.4.14",
+        "@doneisbetter/gds-admin": "3.5.0",
+        "@doneisbetter/gds-core": "3.5.0",
+        "@doneisbetter/gds-theme": "3.5.0",
         "@mantine/core": "^7.9.0",
         "@mantine/hooks": "^7.9.0",
         "@mantine/modals": "^7.9.0",
@@ -5551,7 +5613,7 @@
     },
     "packages/gds-a11y": {
       "name": "@doneisbetter/gds-a11y",
-      "version": "3.4.14",
+      "version": "3.5.0",
       "bin": {
         "gds-a11y": "bin/gds-a11y.mjs"
       },
@@ -5570,14 +5632,14 @@
     },
     "packages/gds-admin": {
       "name": "@doneisbetter/gds-admin",
-      "version": "3.4.14",
+      "version": "3.5.0",
       "dependencies": {
-        "@doneisbetter/gds-core": "3.4.14",
-        "@doneisbetter/gds-theme": "3.4.14"
+        "@doneisbetter/gds-core": "3.5.0",
+        "@doneisbetter/gds-theme": "3.5.0"
       },
       "devDependencies": {
-        "@doneisbetter/gds-core": "3.4.14",
-        "@doneisbetter/gds-theme": "3.4.14",
+        "@doneisbetter/gds-core": "3.5.0",
+        "@doneisbetter/gds-theme": "3.5.0",
         "@mantine/core": "^7.9.0",
         "@mantine/hooks": "^7.9.0",
         "@tabler/icons-react": "^3.5.0",
@@ -5585,8 +5647,8 @@
         "react-dom": "^18.2.0"
       },
       "peerDependencies": {
-        "@doneisbetter/gds-core": "3.4.14",
-        "@doneisbetter/gds-theme": "3.4.14",
+        "@doneisbetter/gds-core": "3.5.0",
+        "@doneisbetter/gds-theme": "3.5.0",
         "@mantine/core": "^7.9.0 || ^8.3.0 || ^9.0.0",
         "@mantine/hooks": "^7.9.0 || ^8.3.0 || ^9.0.0",
         "@tabler/icons-react": "^3.5.0",
@@ -5627,19 +5689,19 @@
     },
     "packages/gds-compliance": {
       "name": "@doneisbetter/gds-compliance",
-      "version": "3.4.14",
+      "version": "3.5.0",
       "bin": {
         "gds-compliance": "bin/gds-compliance.js"
       }
     },
     "packages/gds-core": {
       "name": "@doneisbetter/gds-core",
-      "version": "3.4.14",
+      "version": "3.5.0",
       "dependencies": {
-        "@doneisbetter/gds-theme": "3.4.14"
+        "@doneisbetter/gds-theme": "3.5.0"
       },
       "devDependencies": {
-        "@doneisbetter/gds-theme": "3.4.14",
+        "@doneisbetter/gds-theme": "3.5.0",
         "@mantine/core": "^7.9.0",
         "@mantine/hooks": "^7.9.0",
         "@tabler/icons-react": "^3.5.0",
@@ -5647,7 +5709,7 @@
         "react-dom": "^18.2.0"
       },
       "peerDependencies": {
-        "@doneisbetter/gds-theme": "3.4.14",
+        "@doneisbetter/gds-theme": "3.5.0",
         "@mantine/core": "^7.9.0 || ^8.3.0 || ^9.0.0",
         "@mantine/hooks": "^7.9.0 || ^8.3.0 || ^9.0.0",
         "@tabler/icons-react": "^3.5.0",
@@ -5688,14 +5750,14 @@
     },
     "packages/gds-eslint-config": {
       "name": "@doneisbetter/gds-eslint-config",
-      "version": "3.4.14",
+      "version": "3.5.0",
       "peerDependencies": {
         "eslint": "^9.0.0 || ^10.0.0"
       }
     },
     "packages/gds-theme": {
       "name": "@doneisbetter/gds-theme",
-      "version": "3.4.14",
+      "version": "3.5.0",
       "bin": {
         "gds-theme-tokens": "bin/gds-theme-tokens.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "overrides": {
     "tsup": {
       "esbuild": "0.28.1"
-    }
+    },
+    "vite": "8.0.16"
   }
 }


### PR DESCRIPTION
Finishes the **3.5.0** release so the full `verify:release` suite passes end-to-end. Builds on the AI-agent integration layer (#`84218b0`) and the ClassScout pure-GDS unblock (#`6f87eff`), which were already on `main` but did not yet pass CI.

## What this fixes

The committed ClassScout feature + access-gate demo left three `verify:release` gates red. All are now green:

- **Type-check (`pattern-pages.tsx`):** corrected the access-gate demo against the real runtime types — type-only `GdsAccessGateAction` import (`verbatimModuleSyntax`), `GdsAccessSession.subjectId` (not `userId`/`provider`), and `state` literal narrowing.
- **Type-check (`tsconfig.app.json`):** added `node` to the app type-check so gds-core's `process.env.NODE_ENV` dev-warning idiom (the React/Mantine-standard, Vite-replaced at build) resolves when the app type-checks gds-core source.
- **Site-phrase translations:** regenerated `generated-site-phrases.ts` (9 locales) for the new access-gate demo strings.
- **Dependency audit:** pinned `vite` to `8.0.16`, patching dev-only advisories `GHSA-v6wh-96g9-6wx3` and `GHSA-fx2h-pf6j-xcff` (Windows-specific build tooling; production audit was already clean).

## Verification

`npm run verify:release` passes end-to-end: builds (all packages + playground + reference apps), export-contract, lint, tests, every reference/i18n/access-gate/accessibility/theme/runtime gate, dependency audit, board audit, and Mantine 8/9 + React 19 compatibility smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)