### PR TITLE
fix(ci): poll for page readiness in runtime verifiers (stop flaky /themes failures)

### DIFF
--- a/scripts/verify-accessibility-runtime.mjs
+++ b/scripts/verify-accessibility-runtime.mjs
@@ -190,9 +190,34 @@ async function evaluate(client, expression) {
   return result.result.value;
 }
 
+// Poll until the page has actually rendered a governed surface with readable
+// text, instead of relying on a fixed delay. The Theme Lab (/themes) route is
+// heavy and can take longer than a flat wait to paint under CI load, which
+// previously caused flaky "no visible governed surface" failures.
+async function waitForReady(client, { timeout = 12000, interval = 200 } = {}) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const ready = await evaluate(client, `(() => {
+      const visible = (el) => {
+        if (!el) return false;
+        const s = getComputedStyle(el);
+        const r = el.getBoundingClientRect();
+        return s.visibility !== 'hidden' && s.display !== 'none' && r.width > 0 && r.height > 0;
+      };
+      const surface = [...document.querySelectorAll('.mantine-Card-root,.mantine-Paper-root,[data-gds-owned-contrast],[data-gds-local-contrast]')].some(visible);
+      const hasText = (document.body?.innerText || '').trim().length >= 120;
+      return surface && hasText;
+    })()`);
+    if (ready) return true;
+    await wait(interval);
+  }
+  return false;
+}
+
 async function verifyCase(client, route, testCase) {
   await client.send('Page.navigate', { url: absoluteUrl(route) });
-  await wait(900);
+  await wait(300);
+  await waitForReady(client);
 
   await evaluate(client, `
     localStorage.setItem('gds-reference-theme-selection', JSON.stringify({
@@ -205,7 +230,8 @@ async function verifyCase(client, route, testCase) {
     }));
     location.reload();
   `);
-  await wait(900);
+  await wait(400);
+  await waitForReady(client);
 
   return evaluate(client, `(() => {
     const failures = [];

--- a/scripts/verify-forced-colors-runtime.mjs
+++ b/scripts/verify-forced-colors-runtime.mjs
@@ -185,6 +185,30 @@ async function evaluate(client, expression) {
   return result.result.value;
 }
 
+// Poll until the page has actually rendered a governed surface with readable
+// text, instead of relying on a fixed delay. The Theme Lab (/themes) route is
+// heavy and can take longer than a flat wait to paint under CI load, which
+// previously caused flaky "No visible governed surface found" failures.
+async function waitForReady(client, { timeout = 12000, interval = 200 } = {}) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const ready = await evaluate(client, `(() => {
+      const visible = (el) => {
+        if (!el) return false;
+        const s = getComputedStyle(el);
+        const r = el.getBoundingClientRect();
+        return s.visibility !== 'hidden' && s.display !== 'none' && r.width > 0 && r.height > 0;
+      };
+      const surface = [...document.querySelectorAll('.mantine-Card-root,.mantine-Paper-root,[data-gds-owned-contrast],[data-gds-local-contrast]')].some(visible);
+      const hasText = (document.body?.innerText || '').trim().length >= 120;
+      return surface && hasText;
+    })()`);
+    if (ready) return true;
+    await wait(interval);
+  }
+  return false;
+}
+
 async function verifyCase(client, route, testCase) {
   await client.send('Page.bringToFront');
   await client.send('Emulation.setEmulatedMedia', {
@@ -195,7 +219,8 @@ async function verifyCase(client, route, testCase) {
     ],
   });
   await client.send('Page.navigate', { url: absoluteUrl(route) });
-  await wait(900);
+  await wait(300);
+  await waitForReady(client);
 
   await evaluate(client, `
     localStorage.setItem('gds-reference-theme-selection', JSON.stringify({
@@ -208,7 +233,8 @@ async function verifyCase(client, route, testCase) {
     }));
     location.reload();
   `);
-  await wait(900);
+  await wait(400);
+  await waitForReady(client);
 
   return evaluate(client, `(() => {
     const failures = [];

--- a/scripts/verify-theme-trust-runtime.mjs
+++ b/scripts/verify-theme-trust-runtime.mjs
@@ -194,6 +194,30 @@ async function evaluate(client, expression) {
   return result.result.value;
 }
 
+// Poll until the page has actually rendered a governed surface with readable
+// text, instead of relying on a fixed delay. The Theme Lab (/themes) route is
+// heavy and can take longer than a flat wait to paint under CI load, which
+// previously caused flaky "rendered too little"/"no surface" failures.
+async function waitForReady(client, { timeout = 12000, interval = 200 } = {}) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const ready = await evaluate(client, `(() => {
+      const visible = (el) => {
+        if (!el) return false;
+        const s = getComputedStyle(el);
+        const r = el.getBoundingClientRect();
+        return s.visibility !== 'hidden' && s.display !== 'none' && r.width > 0 && r.height > 0;
+      };
+      const surface = [...document.querySelectorAll('.mantine-Card-root,.mantine-Paper-root,[data-gds-owned-contrast],[data-gds-local-contrast]')].some(visible);
+      const hasText = (document.body?.innerText || '').trim().length >= 120;
+      return surface && hasText;
+    })()`);
+    if (ready) return true;
+    await wait(interval);
+  }
+  return false;
+}
+
 async function setViewport(client, viewport) {
   await client.send('Emulation.setDeviceMetricsOverride', {
     width: viewport.width,
@@ -208,7 +232,8 @@ async function setViewport(client, viewport) {
 async function verifyRouteCase(client, route, testCase, viewport) {
   await setViewport(client, viewport);
   await client.send('Page.navigate', { url: absoluteUrl('/') });
-  await wait(900);
+  await wait(300);
+  await waitForReady(client);
 
   await evaluate(client, `
     localStorage.setItem('gds-reference-theme-selection', JSON.stringify({
@@ -220,9 +245,10 @@ async function verifyRouteCase(client, route, testCase, viewport) {
       fontLane: 'inter'
     }));
   `);
-  await wait(900);
+  await wait(200);
   await client.send('Page.navigate', { url: absoluteUrl(route) });
-  await wait(900);
+  await wait(300);
+  await waitForReady(client);
 
   return evaluate(client, `(() => {
     const failures = [];


### PR DESCRIPTION
## Problem
Main's `validate (mantine-7)` leg went red immediately after the sprint-2 merge, failing `verify:forced-colors-runtime` on the very first case:

```
/themes default/light: No visible governed surface found for forced-colors verification.
```

The `mantine-9` leg passed the **identical** check on the **identical** tree — proving this is non-deterministic flakiness, not a code defect.

## Root cause
The three runtime verifiers (forced-colors, theme-trust, accessibility) waited a fixed `900ms` after navigation before asserting. Sprint 2 made the Theme Lab (`/themes`) route heavier (20-preset vibe gallery), so under CI load it intermittently hadn't painted within 900ms — especially on the first cold page load against a freshly-started preview server.

## Fix
Replace the fixed waits with `waitForReady()`, which polls (up to 12s, 200ms interval) until a governed surface is visibly rendered with ≥120 chars of readable text before asserting. Deterministic, and no slower on the happy path.

Verified locally: both `verify:forced-colors-runtime` and `verify:theme-trust-runtime` pass and exit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)