### PR TITLE
fix(theme): GDS-owned opaque overlay surfaces (#342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable policy changes to the General Design System are recorded here.
 
+## 3.8.0 - Unreleased (vendor boundary sealing)
+
+- **Opaque overlay surfaces** (#342): GDS now owns the painted background of every overlay/dropdown surface (`Popover`, `Menu`, `Select`/`Combobox`, `MultiSelect`, `Autocomplete`, `HoverCard`). `styles.css` sets an opaque, GDS-owned `--gds-overlay-surface` token (white / `--mantine-color-dark-6` / system `Canvas` under forced-colors) and applies it to all dropdown containers with hard fallbacks, so overlays stay solid even when the vendor base stylesheet is absent or an unlayered consumer reset competes. Resolves the cross-client transparent-dropdown failures.
+
 ## 3.6.0 - Unreleased (sprint 2 in-progress)
 
 - **GdsDataTable keyboard navigation** (GH-333): arrow-key row traversal (Up/Down/Home/End), `role="grid"` semantics, `aria-selected`/`aria-rowindex` per row, and `aria-live` screen-reader announcements for focused row position.

--- a/packages/gds-theme/styles.css
+++ b/packages/gds-theme/styles.css
@@ -8,6 +8,40 @@
   transform: translateX(0) !important;
 }
 
+/*
+ * GDS-owned opaque overlay-surface guarantee (issue #342).
+ *
+ * Dropdown / popover / menu / combobox / hovercard containers must never render
+ * a transparent background — even if the vendor base stylesheet is not loaded by
+ * the consumer, or an unlayered consumer reset competes. GDS owns this surface
+ * rather than delegating it to the vendor. The background reads from a GDS-owned
+ * opaque token with hard fallbacks, so it self-heals when --mantine-* vars are
+ * absent. Real class selectors (specificity 0,1,0) reliably beat a `*`-level
+ * consumer reset; forced-colors keeps system Canvas.
+ */
+:root {
+  --gds-overlay-surface: #ffffff;
+}
+html[data-mantine-color-scheme='dark'] {
+  --gds-overlay-surface: var(--mantine-color-dark-6, #25262b);
+}
+@media (forced-colors: active) {
+  :root {
+    --gds-overlay-surface: Canvas;
+  }
+}
+
+.mantine-Popover-dropdown,
+.mantine-Menu-dropdown,
+.mantine-Combobox-dropdown,
+.mantine-Select-dropdown,
+.mantine-MultiSelect-dropdown,
+.mantine-Autocomplete-dropdown,
+.mantine-HoverCard-dropdown,
+[data-gds-overlay-surface] {
+  background-color: var(--gds-overlay-surface);
+}
+
 :root {
   --gds-vibe-primary: #7c3aed;
   --gds-vibe-accent: #06b6d4;


### PR DESCRIPTION
Closes #342 — Wave 1 of the Vendor Boundary Sealing initiative (milestone GDS 3.8.0).

## Problem
GDS delegated the painted background of overlay surfaces to the vendor stylesheet (`.mantine-Popover-dropdown { background: var(--mantine-color-white) }`). When the vendor base CSS isn't loaded by a consumer, or an unlayered consumer reset competes, dropdowns render transparent — making consumer apps unusable.

## Fix
GDS now owns the overlay surface. `styles.css` defines an opaque `--gds-overlay-surface` token (white / `--mantine-color-dark-6` / system `Canvas` under forced-colors) and applies it to every overlay container (`Popover`, `Menu`, `Select`/`Combobox`, `MultiSelect`, `Autocomplete`, `HoverCard`, plus the forward-looking `[data-gds-overlay-surface]` hook) with hard fallbacks. Real class selectors (specificity 0,1,0) reliably beat a `*`-level reset; forced-colors keeps system canvas.

CSS-only, backward compatible, no public API change. Local: alignment, docs-governance, theme/forced-colors runtime verifiers, and builds all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)