### PR TITLE
docs(install): mandatory stylesheet import everywhere + CI guard (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable policy changes to the General Design System are recorded here.
 ## 3.8.0 - Unreleased (vendor boundary sealing)
 
 - **Opaque overlay surfaces** (#342): GDS now owns the painted background of every overlay/dropdown surface (`Popover`, `Menu`, `Select`/`Combobox`, `MultiSelect`, `Autocomplete`, `HoverCard`). `styles.css` sets an opaque, GDS-owned `--gds-overlay-surface` token (white / `--mantine-color-dark-6` / system `Canvas` under forced-colors) and applies it to all dropdown containers with hard fallbacks, so overlays stay solid even when the vendor base stylesheet is absent or an unlayered consumer reset competes. Resolves the cross-client transparent-dropdown failures.
+- **Mandatory stylesheet import documented + guarded** (#344): every consumer integration path — `INSTALLATION_GUIDE.md`, `docs/CLASSSCOUT_INTEGRATION.md`, `docs/AI_AGENT_GUIDE.md`, `README.md`, the Vite/Next `TEMPLATES`, and the playground install code — now shows `import '@doneisbetter/gds-theme/styles.css'` as the first bootstrap step. `verify-install-bootstrap-docs.mjs` fails CI if any tracked integration doc or template omits it, preventing the documentation gap that caused unstyled/transparent surfaces in consumer apps.
 
 ## 3.6.0 - Unreleased (sprint 2 in-progress)
 

--- a/INSTALLATION_GUIDE.md
+++ b/INSTALLATION_GUIDE.md
@@ -66,8 +66,11 @@ npm install @mantine/core @mantine/hooks @mantine/modals @mantine/notifications 
 
 Use the server/client split explicitly. The layout owns the color-scheme script and the provider file owns the single client boundary.
 
+> **Mandatory:** import `@doneisbetter/gds-theme/styles.css` exactly once, before your own app styles. Without it, GDS surfaces — including dropdown/menu/overlay backgrounds — render unstyled (transparent dropdowns).
+
 ```tsx
 // app/layout.tsx
+import '@doneisbetter/gds-theme/styles.css';
 import { ColorSchemeScript } from '@mantine/core';
 import Providers from './providers';
 
@@ -103,6 +106,7 @@ Mount one provider at the application root:
 ```tsx
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import '@doneisbetter/gds-theme/styles.css'; // mandatory: load once, before app styles
 import { GdsProvider } from '@doneisbetter/gds/client';
 import App from './App';
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This repository serves as the central, hardened hub for all UI, UX, and design p
 
 ### Getting Started
 
+> **Mandatory first step for consumers:** import the GDS stylesheet exactly once at your app entry, before your own app styles — `import '@doneisbetter/gds-theme/styles.css'`. Without it, GDS surfaces (including dropdown/menu/overlay backgrounds) render unstyled. See [INSTALLATION_GUIDE.md](INSTALLATION_GUIDE.md).
+
 1. **Familiarize Yourself with the Foundation**: Start by reading [FOUNDATION.md](FOUNDATION.md) to understand the core principles, accessibility baselines, and our strict Mantine token policies.
 2. **Review the Component Contracts**: Before building a new UI component or workflow, check [COMPONENTS_AND_PATTERNS.md](COMPONENTS_AND_PATTERNS.md) to see if a canonical pattern already exists for buttons, tables, modals, public shells, docs pages, or public data surfaces.
 3. **Open the Live Pattern Catalog**: Use [https://sovereignsquad.github.io/general-design-system/patterns](https://sovereignsquad.github.io/general-design-system/patterns) to inspect the public, registry-backed reference site that demonstrates the documented contracts directly.

--- a/TEMPLATES/next-app-layout.tsx.template
+++ b/TEMPLATES/next-app-layout.tsx.template
@@ -1,4 +1,7 @@
 import type { ReactNode } from "react";
+// Mandatory: load the GDS stylesheet exactly once, before your own app styles.
+// Without it, GDS surfaces (including dropdown/overlay backgrounds) render unstyled.
+import "@doneisbetter/gds-theme/styles.css";
 import { ColorSchemeScript } from "@mantine/core";
 import Providers from "./providers";
 

--- a/TEMPLATES/vite-main.tsx.template
+++ b/TEMPLATES/vite-main.tsx.template
@@ -1,5 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+// Mandatory: load the GDS stylesheet exactly once, before your own app styles.
+// Without it, GDS surfaces (including dropdown/overlay backgrounds) render unstyled.
+import "@doneisbetter/gds-theme/styles.css";
 import { GdsProvider } from "@doneisbetter/gds/client";
 import App from "./App";
 

--- a/apps/playground/src/info-pages.tsx
+++ b/apps/playground/src/info-pages.tsx
@@ -44,6 +44,8 @@ const peerCode = `npm install @mantine/core @mantine/hooks @mantine/modals @mant
 const mantineCorePackage = '@mantine/' + 'core';
 
 const nextLayoutCode = `// app/layout.tsx
+// Mandatory: load the GDS stylesheet once, before your app styles.
+import '@doneisbetter/gds-theme/styles.css';
 import { ColorSchemeScript } from '${mantineCorePackage}';
 import Providers from './providers';
 
@@ -72,6 +74,8 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 const viteBootstrapCode = `// src/main.tsx
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+// Mandatory: load the GDS stylesheet once, before your app styles.
+import '@doneisbetter/gds-theme/styles.css';
 import { GdsProvider } from '@doneisbetter/gds/client';
 import App from './App';
 

--- a/docs/AI_AGENT_GUIDE.md
+++ b/docs/AI_AGENT_GUIDE.md
@@ -16,7 +16,13 @@ GDS (`@doneisbetter/gds`) is a governed React design system built on Mantine. It
 npm install @doneisbetter/gds @mantine/core @mantine/hooks @mantine/modals @mantine/notifications @tabler/icons-react react react-dom
 ```
 
-Wrap the app once in `GdsProvider` (the single required root provider — it injects theme, tokens, fonts, color-scheme handling, and locale):
+First, load the GDS stylesheet exactly once at the app entry, before any app styles — this is mandatory; without it GDS surfaces (including dropdown/overlay backgrounds) render unstyled:
+
+```tsx
+import '@doneisbetter/gds-theme/styles.css';
+```
+
+Then wrap the app once in `GdsProvider` (the single required root provider — it injects theme, tokens, fonts, color-scheme handling, and locale):
 
 ```tsx
 import { GdsProvider, AppShell, PageHeader, MetricCard, SemanticButton, EmptyState } from '@doneisbetter/gds';

--- a/docs/CLASSSCOUT_INTEGRATION.md
+++ b/docs/CLASSSCOUT_INTEGRATION.md
@@ -12,6 +12,13 @@ npm install @doneisbetter/gds@3.5.0 @mantine/core @mantine/hooks @mantine/modals
 
 Wrap the app once. For ClassScout the provider belongs in your root layout/providers file:
 
+> **Mandatory first step — load the GDS stylesheet.** Import `@doneisbetter/gds-theme/styles.css` exactly once at your app entry (Vite `main.tsx`, Next `app/layout.tsx`), before your own app styles. Without it, GDS surfaces — including dropdown/menu/overlay backgrounds — render unstyled (transparent dropdowns).
+
+```tsx
+// At your app entry, before app styles:
+import '@doneisbetter/gds-theme/styles.css';
+```
+
 ```tsx
 import { GdsProvider } from '@doneisbetter/gds';
 import { createBrandTheme } from '@doneisbetter/gds-theme';

--- a/scripts/verify-install-bootstrap-docs.mjs
+++ b/scripts/verify-install-bootstrap-docs.mjs
@@ -15,7 +15,14 @@ const files = [
   'TEMPLATES/README.md',
   'TEMPLATES/next-app-layout.tsx.template',
   'TEMPLATES/vite-main.tsx.template',
+  'docs/CLASSSCOUT_INTEGRATION.md',
+  'docs/AI_AGENT_GUIDE.md',
 ];
+
+// The GDS stylesheet import is the single mandatory integration step that paints
+// every GDS surface (including dropdown/overlay backgrounds). Every consumer
+// integration path must document it or the build fails here (issue #344).
+const MANDATORY_STYLESHEET_IMPORT = '@doneisbetter/gds-theme/styles.css';
 
 const requiredByFile = {
   'INSTALLATION_GUIDE.md': [
@@ -24,6 +31,7 @@ const requiredByFile = {
     'ColorSchemeScript',
     'GDS_REGISTRY_RETRIES=8 GDS_REGISTRY_DELAY_MS=7000 npm run verify:published',
     `gds-v${version}`,
+    MANDATORY_STYLESHEET_IMPORT,
   ],
   'COMPATIBILITY_AND_RELEASES.md': [
     `@doneisbetter/gds@${version}`,
@@ -53,6 +61,7 @@ const requiredByFile = {
     'viteBootstrapCode',
     'failureRecoveryCode',
     'fallbackInstallCode',
+    MANDATORY_STYLESHEET_IMPORT,
   ],
   'apps/playground/src/site-copy.ts': [
     `export const targetGdsVersion = '${version}'`,
@@ -65,10 +74,18 @@ const requiredByFile = {
   'TEMPLATES/next-app-layout.tsx.template': [
     'ColorSchemeScript',
     'Providers',
+    MANDATORY_STYLESHEET_IMPORT,
   ],
   'TEMPLATES/vite-main.tsx.template': [
     'GdsProvider',
     '@doneisbetter/gds/client',
+    MANDATORY_STYLESHEET_IMPORT,
+  ],
+  'docs/CLASSSCOUT_INTEGRATION.md': [
+    MANDATORY_STYLESHEET_IMPORT,
+  ],
+  'docs/AI_AGENT_GUIDE.md': [
+    MANDATORY_STYLESHEET_IMPORT,
   ],
 };
 


### PR DESCRIPTION
Closes #344 — Wave 2 of the Vendor Boundary Sealing initiative (milestone GDS 3.8.0). Depends on #342 (merged).

## Problem
The mandatory `import '@doneisbetter/gds-theme/styles.css'` appeared in **zero** consumer-facing docs/templates; the Vite/Next templates imported `GdsProvider` but no stylesheet. Consumers following the recipe shipped unstyled/transparent surfaces.

## Fix
- Add the import as the first bootstrap step to: `INSTALLATION_GUIDE.md`, `docs/CLASSSCOUT_INTEGRATION.md`, `docs/AI_AGENT_GUIDE.md`, `README.md`, `TEMPLATES/vite-main.tsx.template`, `TEMPLATES/next-app-layout.tsx.template`, and the playground install code (`info-pages.tsx`).
- Extend `verify-install-bootstrap-docs.mjs` to require the import in every tracked integration doc/template — CI fails (naming the file) if it's ever dropped.

Verified locally: guard passes; negative test (import removed) fails naming the file; lint, `test:run`, and full `verify:references` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)